### PR TITLE
ci: Allow commits to start with 'Merge' instead of subsystem

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -93,6 +93,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:'
+        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:|^Merge\s\t*'
         error: 'Failed to find subsystem in subject'
         post_error: ${{ env.error_msg }}


### PR DESCRIPTION
Allows merges not down via PRs not to be flagged by the commit checker.

Lines that start with 'Merge ' will be accepted alongside commits with a
subsystem of the form 'subsystem: '.

Fixes #4929

Signed-off-by: Derek Lee <derlee@redhat.com>