### PR TITLE
ci: Add authentication to check_url

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -494,7 +494,13 @@ check_url()
 	local ret
 	local user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
 
-	{ curl -sIL -A "$user_agent" -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
+	# Authenticate for github to increase threshold for rate limiting
+	local curl_args=()
+	if [[ "$url" =~ github\.com && -n "$GITHUB_USER" && -n "$GITHUB_TOKEN" ]]; then
+		curl_args+=("-u ${GITHUB_USER}:${GITHUB_TOKEN}")
+	fi
+
+	{ curl ${curl_args[*]} -sIL -H "Accept-Encoding: zstd, br, gzip, deflate" --max-time "$url_check_timeout_secs" \
 		--retry "$url_check_max_tries" "$url" &>"$curl_out"; ret=$?; } || true
 
 	# A transitory error, or the URL is incorrect,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       TRAVIS_BRANCH: ${{ github.base_ref }}
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
       TRAVIS_PULL_REQUEST_SHA : ${{ github.event.pull_request.head.sha }}
+      GITHUB_USER : ${{ secrets.GITHUB_USER }}
+      GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Install Go
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}


### PR DESCRIPTION
Add github user authentication to check_url to increase rate limit from
60 to 5000.

Fixes #4304

Signed-off-by: Derek Lee <derlee@redhat.com>